### PR TITLE
Remove ugly import for type annotations by using typing library

### DIFF
--- a/BASE_GAME_FILES/PhysicsSimulation.py
+++ b/BASE_GAME_FILES/PhysicsSimulation.py
@@ -1,10 +1,9 @@
-from __future__ import annotations
-
 import math
 import numpy as np
+from typing import Type
 
-import main
 
+CelestialBody = Type["main.CelestialBody"]
 
 class PhysicsSim:
     def __init__(self, starsadstuff: list[CelestialBody]):
@@ -61,6 +60,4 @@ class PhysicsSim:
             body.fy += forces[num][1] / body.mass
 
             body.calcNewPosition()
-
-
-from main import CelestialBody
+            


### PR DESCRIPTION
instead of importing annotations at the start and the module at the end (avoiding circular imports, but very ugly), I created a new Type using the typing module, which avoids this. The change is shown below:

### Original: 
```
from __future__ import annotations
...

from main import CelestialBody
```
### New:
```
from typing import Type
CelestialBody = Type["main.CelestialBody"]
...
```